### PR TITLE
Patterns from hooks

### DIFF
--- a/API.md
+++ b/API.md
@@ -3,7 +3,6 @@
 ## Table of Contents
   - Main API
     + [`statePatterns()`](#statePatterns)
-    + [`stateHook()`](#stateHook)
     + [`renderProp()`](#renderProp)
     + [`decorator()`](#decorator)
   - Utils

--- a/API.md
+++ b/API.md
@@ -1,38 +1,26 @@
 # API
 
 ## Table of Contents
-  + [`statePatterns()`](#statePatterns)
-  + [`stateHook()`](#stateHook)
-  + [`renderProp()`](#renderProp)
-  + [`decorator()`](#decorator)
+  - Main API
+    + [`statePatterns()`](#statePatterns)
+    + [`stateHook()`](#stateHook)
+    + [`renderProp()`](#renderProp)
+    + [`decorator()`](#decorator)
+  - Utils
+    + [`makeHook()`](#makeHook)
+
+
+## Main API
 
 ### statePatterns
 `statePatterns` - _Creates an implementation of the state decorator, hook, and render prop provider patterns_
 ```javascript
 /**
- * @param {Object} initialState The state to use initially
- * @param {Function} handlers A function that takes state as the argument and
- *    returns an object of handlers
- * @param {?String} nameSpace An optional string to namespace the
- *    state and handlers under.
+ * @param {Function} stateHook A custom React hook to manage state.
+ *    Important: This hook will receive props and must return an object.
  * @return {Object} An object containing the state decorator, hook, and
  *    render prop provider patterns.
  *     i.e. { useHook, withState, State }
- */
-```
-
-### stateHook
-+ `stateHook` - _Creates an implementation of the state hook provider pattern._
-```javascript
-/**
- * @param {Object} initialState The state to use initially
- * @param {Function} handlers A function that takes state as the argument and
- *    returns an object of handlers
- * @param {?String} nameSpace An optional string to namespace the
- *    state and handlers under.
- * @return {Function} A custom state hook function that returns the state and
- *    handlers in an object literal (Optionally wrapped in the namespace if
- *    provided)
  */
 ```
 
@@ -60,5 +48,38 @@
  *    state and handlers under.
  * @return {Function} The decorator HOC function that takes in a React Component
  *    and decorates it with the state.
+ */
+```
+
+
+## Utils
+
+### hookSchema
++ `hookSchema` - _Creates a hook schema that can be returned from React hooks._
+```javascript
+/**
+ * @param {Any} state The state which will be passed down to providers.
+ * @param {Object} handlers The state handlers which will be passed down to providers.
+ * @param {?String} nameSpace An optional string to namespace the
+ *    state and handlers under.
+ * @return {Object} An object containing with the handlers and state as keys.
+ *    Optionally wrapped in the nameSpace. i.e. { nameSpace: { handlers: {}, state: {} } }
+ */
+```
+
+### stateHook
++ `stateHook` - _Creates a custom React state hook that accepts props and returns an object of the form:_
+`{ nameSpace: { handlers: {}, state: {} } } }`
+```javascript
+/**
+ * @param {Object} initialState The state to use initially
+ * @param {Function} handlers A function that takes state as the argument and
+ *    returns an object of handlers i.e. (state) => ({ myHandler: () => ({ ...state }) })
+ *    Each handler's return value will be used as the new state when invoked.
+ * @param {?String} nameSpace An optional string to namespace the
+ *    state and handlers under.
+ * @return {Function} A custom React state hook that accepts props and returns an object
+ *    of the form { nameSpace: { handlers: {}, state: {} } } }
+ *     i.e. { useHook, withState, State }
  */
 ```

--- a/API.md
+++ b/API.md
@@ -7,7 +7,8 @@
     + [`renderProp()`](#renderProp)
     + [`decorator()`](#decorator)
   - Utils
-    + [`makeHook()`](#makeHook)
+    + [`hookSchema()`](#hookSchema)
+    + [`stateHook()`](#stateHook)
 
 
 ## Main API

--- a/API.md
+++ b/API.md
@@ -17,7 +17,7 @@
 ```javascript
 /**
  * @param {Function} stateHook A custom React hook to manage state.
- *    Important: This hook will receive props and must return an object.
+ *    Important: This hook will receive props and must return an object literal.
  * @return {Object} An object containing the state decorator, hook, and
  *    render prop provider patterns.
  *     i.e. { useHook, withState, State }
@@ -28,11 +28,8 @@
 + `renderProp` - _Creates an implementation of the state render prop provider pattern._
 ```javascript
 /**
- * @param {Object} initialState The state to use initially
- * @param {Function} handlers A function that takes state as the argument and
- *    returns an object of handlers
- * @param {?String} nameSpace An optional string to namespace the
- *    state and handlers under.
+ * @param {Function} stateHook A custom React hook to manage state.
+ *    Important: This hook will receive props and must return an object literal.
  * @return {Component} A component with the state injected into the render prop.
  */
 ```
@@ -41,11 +38,8 @@
 + `decorator` -  _Creates an implementation of the state decorator provider pattern._
 ```javascript
 /**
- * @param {Object} initialState The state to use initially
- * @param {Function} handlers A function that takes state as the argument and
- *    returns an object of handlers
- * @param {?String} nameSpace An optional string to namespace the
- *    state and handlers under.
+ * @param {Function} stateHook A custom React hook to manage state.
+ *    Important: This hook will receive props and must return an object literal.
  * @return {Function} The decorator HOC function that takes in a React Component
  *    and decorates it with the state.
  */

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 Tiny utility package for easily creating reusable implementations of React state provider patterns.
 
-⚠️  Powered by React Hooks under the hood. (This library has a peer dependency on `react: ^16.8.0`)
-
 🚀  [react-state-patterns](https://www.npmjs.com/package/react-state-patterns) makes it easy to (and reduces boilerplate) create implementations of common React state provider patterns.
+
+⚠️  Powered by React Hooks under the hood. (This library has a peer dependency on `react: ^16.8.0`)
 
 # Getting Started
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ npm install react-state-patterns --save
 [View API Docs Here](https://github.com/mcclayton/react-state-patterns/blob/master/API.md)
 
 ### Creating State Patterns
+
+## Directly From Hook
 ```jsx
-import { statePatterns } from 'react-state-patterns';
+import { statePatterns, hookSchema } from 'react-state-patterns';
 
 // Create the state patterns
 const Counter = createStatePatterns(props => {
@@ -30,10 +32,27 @@ const Counter = createStatePatterns(props => {
     incrementBy: value => setCount(count + value),
     decrementBy: value => setCount(count - value)
   };
-  // getHookSchema(...)
+  // hookSchema(...)
   //    => { counter: { state: { count: 0 }, handlers: { incrementBy: (v) => {...}, decrementBy: (v) => {...} } } }
-  return getHookSchema({ count: count }, handlers, "counter");
+  return hookSchema({ count: count }, handlers, "counter");
 });
+```
+
+## Using stateHook
+[stateHook API Docs](https://github.com/mcclayton/react-state-patterns/blob/master/API.md#stateHook)
+```jsx
+import { statePatterns, stateHook } from 'react-state-patterns';
+
+// Create the state patterns
+const Counter = createStatePatterns(
+  createStateHook(
+    { count: 0 },
+    state => ({
+      incrementBy: value => ({ ...state, count: state.count + value }),
+      decrementBy: value => ({ ...state, count: state.count - value })
+    }),
+    "counter"
+  ));
 ```
 
 ### Use the patterns

--- a/README.md
+++ b/README.md
@@ -24,18 +24,16 @@ npm install react-state-patterns --save
 import { statePatterns } from 'react-state-patterns';
 
 // Create the state patterns
-const Counter = statePatterns(
-  { count: 0 },
-  state => ({
-    decrementBy: (value) => ({
-      count: state.count - value
-    }),
-    incrementBy: (value) => ({
-      count: state.count + value
-    }),
-  }),
-  "counter"
-);
+const Counter = createStatePatterns(props => {
+  const [count, setCount] = useState(props.initialValue || 0);
+  const handlers = {
+    incrementBy: value => setCount(count + value),
+    decrementBy: value => setCount(count - value)
+  };
+  // getHookSchema(...)
+  //    => { counter: { state: { count: 0 }, handlers: { incrementBy: (v) => {...}, decrementBy: (v) => {...} } } }
+  return getHookSchema({ count: count }, handlers, "counter");
+});
 ```
 
 ### Use the patterns
@@ -53,13 +51,13 @@ const Displayer = ({ counter: { state, handlers }}) => (
 const StatefulDisplayer = Counter.withState(Displayer);
 
 const rootElement = document.getElementById("root");
-ReactDOM.render(<StatefulDisplayer initialState={{ count: 0 }} />, rootElement);
+ReactDOM.render(<StatefulDisplayer initialValue={5} />, rootElement);
 ```
 
 #### Render Prop Pattern
 ```jsx
 const Displayer = (props) => (
-  <Counter.State initialState={{ count: 0 }}>
+  <Counter.State initialValue={5}>
     {({ counter: { state, handlers } }) => (
       <React.Fragment>
         <div>{state.count}</div>
@@ -74,7 +72,7 @@ const Displayer = (props) => (
 #### Custom Hook Pattern
 ```jsx
 const Displayer = (props) => {
-  const { counter: { state, handlers } } = Counter.useHook({ initialState: { count: 0 } });
+  const { counter: { state, handlers } } = Counter.useHook({ initialValue: 5 });
 
   return (
     <React.Fragment>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-state-patterns",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Tiny utility package for easily creating reusable implementations of React state provider patterns.",
   "main": "dist/main.js",
   "scripts": {

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,10 @@
+class StatePatternError extends Error {
+  constructor(...args) {
+    super(...args);
+    this.name = 'StatePatternError';
+  }
+}
+
+export default {
+  StatePatternError,
+};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,11 @@
+import { StatePatternError } from './errors';
+
+export const wrapStateHook = (stateHook) => (props) => {
+  const retVal = stateHook(props);
+  if (!retVal || retVal.constructor !== Object) {
+    throw new StatePatternError(
+      `React hook must return an object literal \n Return was: ${retVal}`
+    );
+  }
+  return retVal;
+};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,12 @@
 import { StatePatternError } from './errors';
 
+export const defaultHandlers = (state) => ({
+  setState: (newState) => ({
+    ...state,
+    ...newState,
+  }),
+});
+
 export const wrapStateHook = (stateHook) => (props) => {
   const retVal = stateHook(props);
   if (!retVal || retVal.constructor !== Object) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,37 +1,88 @@
 import React, { useState } from 'react';
-
-/**
- * Helpers
- */
-const _defaultHandlers = (state) => ({
-  setState: (newState) => ({
-    ...state,
-    ...newState,
-  }),
-});
+import { wrapStateHook } from './helpers';
 
 /**
  * Main API
  */
 
 /**
- * Creates an implementation of the state hook pattern.
- * @param {Object} initialState The state to use initially
- * @param {Function} handlers A function that takes state as the argument and
- *    returns an object of handlers
+ * Creates an implementation of the state render prop pattern.
+ * @param {Function} stateHook A custom React hook to manage state.
+ *    Important: This hook will receive props and must return an object.
+ * @return {Component} A component with the state injected into the render prop.
+ */
+const createRenderProp = (stateHook) => {
+  const wrappedHook = wrapStateHook(stateHook);
+  return ({ children, ...props }) => {
+    return typeof children === 'function'
+      ? children(wrappedHook(props))
+      : children;
+  };
+};
+
+/**
+ * Creates an implementation of the state decorator pattern.
+ * @param {Function} stateHook A custom React hook to manage state.
+ *    Important: This hook will receive props and must return an object.
+ * @return {Function} The decorator HOC function that takes in a React Component
+ *    and decorates it with the state.
+ */
+const createDecorator = (stateHook) => (Component) => (props) => (
+  <Component {...{ ...stateHook(props), ...props }} />
+);
+
+/**
+ * Creates an implementation of the state decorator, hook, and render
+ * prop pattern.
+ * @param {Function} stateHook A custom React hook to manage state.
+ *    Important: This hook will receive props and must return an object.
+ * @return {Object} An object containing the state decorator, hook, and
+ *    render prop provider patterns.
+ *     i.e. { useHook, withState, State }
+ */
+const createStatePatterns = (stateHook) => {
+  const wrappedStateHook = wrapStateHook(stateHook);
+  const renderProp = createRenderProp(stateHook);
+  const Decorator = createDecorator(stateHook);
+
+  return {
+    useHook: wrappedStateHook,
+    withState: Decorator,
+    State: renderProp,
+  };
+};
+
+/**
+ * Creates a hook schema that can be returned from React hooks.
+ * @param {Any} state The state which will be passed down to providers.
+ * @param {Object} handlers The state handlers which will be passed down to providers.
  * @param {?String} nameSpace An optional string to namespace the
  *    state and handlers under.
- * @return {Function} A custom state hook function that returns the state and
- *    handlers in an object literal (Optionally wrapped in the namespace if
- *    provided)
+ * @return {Object} An object containing with the handlers and state as keys.
+ *    Optionally wrapped in the nameSpace. i.e. { nameSpace: { handlers: {}, state: {} } }
+ */
+const getHookSchema = (state, handlers = {}, nameSpace) => {
+  const hookSchema = { handlers, state };
+  return nameSpace ? { [nameSpace]: hookSchema } : hookSchema;
+};
+
+/**
+ * @param {Object} initialState The state to use initially
+ * @param {Function} handlers A function that takes state as the argument and
+ *    returns an object of handlers i.e. (state) => ({ myHandler: () => ({ ...state }) })
+ *    Each handler's return value will be used as the new state when invoked.
+ * @param {?String} nameSpace An optional string to namespace the
+ *    state and handlers under.
+ * @return {Object} An object containing the state decorator, hook, and
+ *    render prop provider patterns.
+ *     i.e. { useHook, withState, State }
  */
 const createStateHook = (
   initialState = {},
   handlers = _defaultHandlers,
   nameSpace
 ) => (props) => {
-  const hookInitialState = props && props.initialState;
-  const [state, setState] = useState(hookInitialState || initialState);
+  const [state, setState] = useState(initialState);
 
   const handlersWithState = handlers(state);
   const stateHandlers = Object.keys(handlersWithState).reduce(
@@ -45,106 +96,23 @@ const createStateHook = (
     },
     {}
   );
-
-  const hookSchema = {
-    handlers: {
-      setState,
-      ...stateHandlers,
-    },
-    state,
-  };
-
-  if (nameSpace) {
-    return { [nameSpace]: hookSchema };
-  } else {
-    return hookSchema;
-  }
-};
-
-/**
- * Creates an implementation of the state render prop pattern.
- * @param {Object} initialState The state to use initially
- * @param {Function} handlers A function that takes state as the argument and
- *    returns an object of handlers
- * @param {?String} nameSpace An optional string to namespace the
- *    state and handlers under.
- * @return {Component} A component with the state injected into the render prop.
- */
-const createRenderProp = (
-  initialState = {},
-  handlers = _defaultHandlers,
-  nameSpace
-) => {
-  const stateHook = createStateHook(initialState, handlers, nameSpace);
-  const renderProp = ({ children, ...props }) => {
-    return typeof children === 'function'
-      ? children(stateHook(props))
-      : children;
-  };
-  return renderProp;
-};
-
-/**
- * Creates an implementation of the state decorator pattern.
- * @param {Object} initialState The state to use initially
- * @param {Function} handlers A function that takes state as the argument and
- *    returns an object of handlers
- * @param {?String} nameSpace An optional string to namespace the
- *    state and handlers under.
- * @return {Function} The decorator HOC function that takes in a React Component
- *    and decorates it with the state.
- */
-const createDecorator = (
-  initialState = {},
-  handlers = _defaultHandlers,
-  nameSpace
-) => {
-  const stateHook = createStateHook(initialState, handlers, nameSpace);
-  const Decorator = (Component) => (props) => (
-    <Component {...{ ...stateHook(props), ...props }} />
-  );
-  return Decorator;
-};
-
-/**
- * Creates an implementation of the state decorator, hook, and render
- * prop pattern.
- * @param {Object} initialState The state to use initially
- * @param {Function} handlers A function that takes state as the argument and
- *    returns an object of handlers
- * @param {?String} nameSpace An optional string to namespace the
- *    state and handlers under.
- * @return {Object} An object containing the state decorator, hook, and
- *    render prop provider patterns.
- *     i.e. { useHook, withState, State }
- */
-const createStatePatterns = (
-  initialState = {},
-  handlers = _defaultHandlers,
-  nameSpace
-) => {
-  const stateHook = createStateHook(initialState, handlers, nameSpace);
-  const renderProp = createRenderProp(initialState, handlers, nameSpace);
-  const Decorator = createDecorator(initialState, handlers, nameSpace);
-
-  return {
-    useHook: stateHook,
-    withState: Decorator,
-    State: renderProp,
-  };
+  return getHookSchema(state, stateHandlers, nameSpace);
 };
 
 /**
  * Export the API
  */
 export const statePatterns = createStatePatterns;
-export const stateHook = createStateHook;
 export const renderProp = createRenderProp;
 export const decorator = createDecorator;
+export const makeHook = createStateHook;
+
+export const hookSchema = getHookSchema;
 
 export default {
   statePatterns,
   stateHook,
   renderProp,
   decorator,
+  hookSchema,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { wrapStateHook } from './helpers';
+import { wrapStateHook, defaultHandlers } from './helpers';
 
 /**
  * Main API
@@ -73,13 +73,13 @@ const getHookSchema = (state, handlers = {}, nameSpace) => {
  *    Each handler's return value will be used as the new state when invoked.
  * @param {?String} nameSpace An optional string to namespace the
  *    state and handlers under.
- * @return {Object} An object containing the state decorator, hook, and
- *    render prop provider patterns.
+ * @return {Function} A custom React state hook that accepts props and returns an object
+ *    of the form { nameSpace: { handlers: {}, state: {} } } }
  *     i.e. { useHook, withState, State }
  */
 const createStateHook = (
   initialState = {},
-  handlers = _defaultHandlers,
+  handlers = defaultHandlers,
   nameSpace
 ) => (props) => {
   const [state, setState] = useState(initialState);
@@ -111,8 +111,8 @@ export const hookSchema = getHookSchema;
 
 export default {
   statePatterns,
-  stateHook,
   renderProp,
   decorator,
+  stateHook,
   hookSchema,
 };


### PR DESCRIPTION
Currently all the State Provider Pattern creators take in arguments of the form

(initialState, handlers, nameSpace)
This changes the API to provide more flexibility by making these all take in a React Hook and wrap it in the provider implementation.

A couple utils were created and exposed as the util API: `hookSchema` and `stateHook`

Resolves Issue: https://github.com/mcclayton/react-state-patterns/issues/1