### PR TITLE
Add support for context pattern

### DIFF
--- a/API.md
+++ b/API.md
@@ -5,6 +5,7 @@
     + [`statePatterns()`](#statePatterns)
     + [`renderProp()`](#renderProp)
     + [`decorator()`](#decorator)
+    + [`context()`](#context)
   - Utils
     + [`hookSchema()`](#hookSchema)
     + [`stateHook()`](#stateHook)
@@ -13,14 +14,15 @@
 ## Main API
 
 ### statePatterns
-`statePatterns` - _Creates an implementation of the state decorator, hook, and render prop provider patterns_
+`statePatterns` - _Creates an implementation of the state decorator, hook, render prop, and context provider/consumer patterns._
+
 ```javascript
 /**
  * @param {Function} stateHook A custom React hook to manage state.
  *    Important: This hook will receive props and must return an object literal.
  * @return {Object} An object containing the state decorator, hook, and
  *    render prop provider patterns.
- *     i.e. { useHook, withState, State }
+ *     i.e. { useHook, withState, State, Provider, Consumer }
  */
 ```
 
@@ -42,6 +44,17 @@
  *    Important: This hook will receive props and must return an object literal.
  * @return {Function} The decorator HOC function that takes in a React Component
  *    and decorates it with the state.
+ */
+```
+
+### context
++ `context` -  _Creates an implementation of the state Context Provider/Consumer pattern._
+```javascript
+/**
+ * @param {Function} stateHook A custom React hook to manage state.
+ *    Important: This hook will receive props and must return an object.
+ * @return {Object} An Object containing both the React Context
+ *    Provider and Consumer. i.e. { Consumer: ..., Provider: ... }
  */
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ const Counter = statePatterns(
       decrementBy: value => ({ ...state, count: state.count - value })
     }),
     "counter"
-  ));
+  )
+);
 ```
 
 ### Use the patterns
@@ -85,6 +86,23 @@ const Displayer = (props) => (
       </React.Fragment>
     )}
   </Counter.State>
+);
+```
+
+#### Context Provider/Consumer Pattern
+```jsx
+const Displayer = (props) => (
+  <Counter.Provider initialValue={5}>
+    <Counter.Consumer>
+      {({ counter: { state, handlers } }) => (
+        <React.Fragment>
+          <div>{state.count}</div>
+          <button onClick={() => handlers.decrementBy(1)}>Decrement</button>
+          <button onClick={() => handlers.incrementBy(1)}>Increment</button>
+        </React.Fragment>
+      )}
+    </Counter.Consumer>
+  </Counter.Provider>
 );
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-state-patterns",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Tiny utility package for easily creating reusable implementations of React state provider patterns.",
   "main": "dist/main.js",
   "scripts": {
@@ -29,7 +29,8 @@
     "hooks",
     "decorator",
     "patterns",
-    "render props"
+    "render props",
+    "context"
   ],
   "peerDependencies": {
     "react": "^16.8.0"

--- a/src/index.js
+++ b/src/index.js
@@ -32,23 +32,46 @@ const createDecorator = (stateHook) => (Component) => (props) => (
 );
 
 /**
- * Creates an implementation of the state decorator, hook, and render
- * prop pattern.
+ * Creates an implementation of the state Context Provider/Consumer pattern.
+ * @param {Function} stateHook A custom React hook to manage state.
+ *    Important: This hook will receive props and must return an object.
+ * @return {Object} An Object containing both the React Context
+ *    Provider and Consumer. i.e. { Consumer: ..., Provider: ... }
+ */
+const createContext = (stateHook) => {
+  const wrappedHook = wrapStateHook(stateHook);
+  const Context = React.createContext({});
+  const Provider = ({ children, ...props }) => (
+    <Context.Provider value={wrappedHook(props)}>{children}</Context.Provider>
+  );
+
+  return {
+    Provider,
+    Consumer: Context.Consumer,
+  };
+};
+
+/**
+ * Creates an implementation of the state decorator, hook, render
+ * prop, and context provider/consumer pattern.
  * @param {Function} stateHook A custom React hook to manage state.
  *    Important: This hook will receive props and must return an object.
  * @return {Object} An object containing the state decorator, hook, and
  *    render prop provider patterns.
- *     i.e. { useHook, withState, State }
+ *     i.e. { useHook, withState, State, Provider, Consumer }
  */
 const createStatePatterns = (stateHook) => {
   const wrappedStateHook = wrapStateHook(stateHook);
   const renderProp = createRenderProp(stateHook);
   const Decorator = createDecorator(stateHook);
+  const Context = createContext(stateHook);
 
   return {
     useHook: wrappedStateHook,
     withState: Decorator,
     State: renderProp,
+    Provider: Context.Provider,
+    Consumer: Context.Consumer,
   };
 };
 
@@ -105,6 +128,7 @@ const createStateHook = (
 export const statePatterns = createStatePatterns;
 export const renderProp = createRenderProp;
 export const decorator = createDecorator;
+export const createContext = context;
 export const stateHook = createStateHook;
 
 export const hookSchema = getHookSchema;
@@ -114,5 +138,6 @@ export default {
   renderProp,
   decorator,
   stateHook,
+  context,
   hookSchema,
 };


### PR DESCRIPTION
Adding in support for the React Context Provider/Consumer pattern.
```javascript
const { Provider, Consumer  } = context(props => {
  const [count, setCount] = useState(props.initialValue || 0);
  const handlers = {
    incrementBy: value => setCount(count + value),
    decrementBy: value => setCount(count - value)
  };
  // hookSchema(...)
  //    => { counter: { state: { count: 0 }, handlers: { incrementBy: (v) => {...}, decrementBy: (v) => {...} } } }
  return hookSchema({ count: count }, handlers, "counter");
});
```

Resolves: https://github.com/mcclayton/react-state-patterns/issues/2