### PR TITLE
Declare React as External Dependency (Webpack)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-state-patterns",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Tiny utility package for easily creating reusable implementations of React state provider patterns.",
   "main": "dist/main.js",
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,4 +15,13 @@ module.exports = {
     libraryTarget: 'umd',
     filename: 'main.js',
   },
+  externals: {
+    react: {
+      root: 'React',
+      commonjs2: 'react',
+      commonjs: 'react',
+      amd: 'react',
+      umd: 'react',
+    },
+  },
 };


### PR DESCRIPTION
Since React is a peer dependency, marking it as an external reference in the webpack config.