### PR TITLE
Throw errors for invalid state hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-state-patterns",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Tiny utility package for easily creating reusable implementations of React state provider patterns.",
   "main": "dist/main.js",
   "scripts": {

--- a/src/__tests__/helpers.test.js
+++ b/src/__tests__/helpers.test.js
@@ -2,6 +2,13 @@ import { wrapStateHook } from '../helpers';
 import { StatePatternError } from '../errors';
 
 describe('wrapStateHook', () => {
+  describe('when wrapping invalid hook', () => {
+    it('throws a StatePatternError', () => {
+      const stateHook = 'I am not a valid state hook.';
+      expect(wrapStateHook(stateHook)).toThrowError(StatePatternError);
+    });
+  });
+
   describe('when wrapping hook with no return', () => {
     it('throws a StatePatternError', () => {
       const stateHook = () => {};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,6 +8,12 @@ export const defaultHandlers = (state) => ({
 });
 
 export const wrapStateHook = (stateHook) => (props) => {
+  const hookType = typeof stateHook;
+  if (hookType !== 'function') {
+    throw new StatePatternError(
+      `Attempting to wrap invalid hook. Hook must be a function but received: ${hookType}.`
+    );
+  }
   const retVal = stateHook(props);
   if (!retVal || retVal.constructor !== Object) {
     throw new StatePatternError(


### PR DESCRIPTION
When wrapping a state hook using the `wrapStateHook` helper, we expect a function. This makes that expectation contractual and throws if a function is not passed in.