### PR TITLE
Add documentation generation with esdoc

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -1,0 +1,15 @@
+{
+  "source": "./src/api",
+  "destination": "./docs",
+  "plugins": [
+    {
+      "name": "esdoc-standard-plugin"
+    },
+    {
+      "name": "esdoc-ecmascript-proposal-plugin",
+      "option": {
+        "all": true
+      }
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib
 node_modules
 .DS_Store
 dist
+docs

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "jest",
     "build": "webpack --mode production",
     "dev": "webpack --mode development",
+    "docs": "rimraf ./docs && ./node_modules/.bin/esdoc",
     "prepublishOnly": "yarn build"
   },
   "files": [
@@ -53,6 +54,9 @@
     "babel-loader": "^8.0.6",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.14.0",
+    "esdoc": "^1.1.0",
+    "esdoc-ecmascript-proposal-plugin": "^1.0.0",
+    "esdoc-standard-plugin": "^1.0.0",
     "eslint": "^6.4.0",
     "eslint-config-prettier": "^6.3.0",
     "husky": "^1.3.1",
@@ -61,6 +65,7 @@
     "prettier": "^1.18.2",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
+    "rimraf": "^3.0.0",
     "webpack": "^4.41.0",
     "webpack-cli": "^3.3.9"
   }


### PR DESCRIPTION
This adds the ability to automatically generate documentation for the main API using jsdoc syntax.
In a later PR, I may replace the API.md with this setup.